### PR TITLE
Add filesystem rootpath on the provider

### DIFF
--- a/packages/forestry-graphql/src/datasources/fileSystemManager.ts
+++ b/packages/forestry-graphql/src/datasources/fileSystemManager.ts
@@ -1,25 +1,36 @@
 import fs from "fs";
 import matterOrig, { Input, GrayMatterOption } from "gray-matter";
 import { DataSource } from "./datasource";
+import path from "path";
 
 export class FileSystemManager implements DataSource {
+  rootPath: string;
+  constructor(rootPath: string) {
+    this.rootPath = rootPath;
+  }
   getData = async <T>(filepath: string): Promise<T> => {
-    const result = matter(await fs.readFileSync(filepath));
+    const result = matter(await fs.readFileSync(this.getFullPath(filepath)));
 
     // @ts-ignore
     return result;
   };
-  writeData = async <T>(path: string, content: any, data: any) => {
+  writeData = async <T>(filepath: string, content: any, data: any) => {
     const string = stringify(content, data);
-    await fs.writeFileSync(path, string);
 
-    return await this.getData<T>(path);
-  };
-  getDirectoryList = async (path: any) => {
-    const list = await fs.readdirSync(path);
+    const fullPath = this.getFullPath(filepath);
+    await fs.writeFileSync(fullPath, string);
 
-    return list.map((item) => `${path}/${item}`);
+    return await this.getData<T>(fullPath);
   };
+  getDirectoryList = async (filepath: any) => {
+    const list = await fs.readdirSync(this.getFullPath(filepath));
+
+    return list.map((item) => `${filepath}/${item}`);
+  };
+
+  private getFullPath(relPath: string) {
+    return path.join(this.rootPath, relPath);
+  }
 }
 
 const stringify = (content: string, data: object) => {


### PR DESCRIPTION
Add filesystem rootpath on the provider, so buildSchema can be agnostic of the absolute path (we won't need that for the database implementation).