### PR TITLE
Fix circular dependency warning

### DIFF
--- a/packages/graphql/src/fieldGenerator.ts
+++ b/packages/graphql/src/fieldGenerator.ts
@@ -3,17 +3,23 @@ import { FieldData, GeneratedFieldsType } from "./fields/types";
 import { FieldType } from "./datasources/datasource";
 import { getFieldType } from "./fields";
 
+export type GenerateFieldAccessorsType = {
+  fmt: string;
+  fields: FieldType[];
+  config: { rootPath: string; siteLookup: string };
+  fieldData: FieldData;
+};
+
+export type GenerateFieldAccessorsFunction = (
+  args: GenerateFieldAccessorsType
+) => GeneratedFieldsType;
+
 export const generateFieldAccessors = ({
   fmt,
   fields,
   config,
   fieldData,
-}: {
-  fmt: string;
-  fields: FieldType[];
-  config: { rootPath: string; siteLookup: string };
-  fieldData: FieldData;
-}): GeneratedFieldsType => {
+}: GenerateFieldAccessorsType): GeneratedFieldsType => {
   const accumulator: GeneratedFieldsType = {
     getters: {},
     setters: {},
@@ -26,6 +32,7 @@ export const generateFieldAccessors = ({
       field,
       config,
       fieldData,
+      generateFieldAccessors,
     });
 
     accumulator.getters[field.name] = getter;

--- a/packages/graphql/src/fields/fieldgroup.ts
+++ b/packages/graphql/src/fields/fieldgroup.ts
@@ -1,4 +1,5 @@
 import { ConfigType, FieldData, FieldSetter } from "./types";
+import type { GenerateFieldAccessorsFunction } from "../fieldGenerator";
 import { FieldGroupField, FieldType } from "../datasources/datasource";
 import {
   GraphQLError,
@@ -10,18 +11,19 @@ import {
 } from "graphql";
 
 import { friendlyFMTName } from "@forestryio/graphql-helpers";
-import { generateFieldAccessors } from "../fieldGenerator";
 
 export const field_group = ({
   fmt,
   field,
   config,
   fieldData,
+  generateFieldAccessors,
 }: {
   fmt: string;
   field: FieldGroupField;
   config: ConfigType;
   fieldData: FieldData;
+  generateFieldAccessors: GenerateFieldAccessorsFunction;
 }) => {
   const { getters, setters, mutators } = generateFieldAccessors({
     fmt: `${fmt}_${field.name}`,

--- a/packages/graphql/src/fields/fieldgrouplist.ts
+++ b/packages/graphql/src/fields/fieldgrouplist.ts
@@ -1,4 +1,5 @@
 import { ConfigType, FieldData } from "./types";
+import type { GenerateFieldAccessorsFunction } from "../fieldGenerator";
 import { FieldGroupListField, FieldType } from "../datasources/datasource";
 import {
   GraphQLError,
@@ -10,18 +11,19 @@ import {
 } from "graphql";
 
 import { friendlyFMTName } from "@forestryio/graphql-helpers";
-import { generateFieldAccessors } from "../fieldGenerator";
 
 export const field_group_list = ({
   fmt,
   field,
   config,
   fieldData,
+  generateFieldAccessors,
 }: {
   fmt: string;
   field: FieldGroupListField;
   config: ConfigType;
   fieldData: FieldData;
+  generateFieldAccessors: GenerateFieldAccessorsFunction;
 }) => {
   const { getters, setters, mutators } = generateFieldAccessors({
     fmt: `${fmt}_${field.name}`,

--- a/packages/graphql/src/fields/index.ts
+++ b/packages/graphql/src/fields/index.ts
@@ -1,4 +1,5 @@
 import { FieldAccessorTypes, FieldData } from "./types";
+import type { GenerateFieldAccessorsFunction } from "../fieldGenerator";
 
 import { FieldType } from "../datasources/datasource";
 import { GraphQLError } from "graphql";
@@ -21,11 +22,13 @@ export const getFieldType = ({
   field,
   config,
   fieldData,
+  generateFieldAccessors,
 }: {
   fmt: string;
   field: FieldType;
   config: { rootPath: string; siteLookup: string };
   fieldData: FieldData;
+  generateFieldAccessors: GenerateFieldAccessorsFunction;
 }): FieldAccessorTypes => {
   switch (field.type) {
     case "text":
@@ -49,9 +52,21 @@ export const getFieldType = ({
     case "image_gallery":
       return image_gallery({ fmt, field, config });
     case "field_group":
-      return field_group({ fmt, field, config, fieldData });
+      return field_group({
+        fmt,
+        field,
+        config,
+        fieldData,
+        generateFieldAccessors,
+      });
     case "field_group_list":
-      return field_group_list({ fmt, field, config, fieldData });
+      return field_group_list({
+        fmt,
+        field,
+        config,
+        fieldData,
+        generateFieldAccessors,
+      });
     case "blocks":
       return blocks({ field, config, fieldData });
     default:


### PR DESCRIPTION
I'm getting a warning about a circular dependency, which is no surprise given how recursive the graphql code is. This passes the function through recursively so it doesn't need to be imported in the other file. Not sure if this is the best solution but it seems like the only way from what I could see.

cc @mittonface