### PR TITLE
Make custom API options explicit

### DIFF
--- a/apps/demo/utils/createClient.ts
+++ b/apps/demo/utils/createClient.ts
@@ -21,6 +21,6 @@ export const createClient = (editMode: boolean) => {
     realm: process.env.REALM_NAME,
     clientId: process.env.SITE_CLIENT_ID,
     redirectURI: "",
-    customAPI: !editMode ? DEFAULT_LOCAL_TINA_GQL_SERVER_URL : undefined,
+    customContentApiUrl: !editMode ? DEFAULT_LOCAL_TINA_GQL_SERVER_URL : undefined,
   });
 };

--- a/packages/client/readme.md
+++ b/packages/client/readme.md
@@ -178,8 +178,7 @@ export default withTina(MyApp, {
       realm: "your-realm-name", // this was set by you in the previous step
       clientId: "your-client-id", // this is visible in your Tina.io dashboard
       redirectURI: "your webpage url", //e.g http://localhost:3000
-      // identityProxy: "", // we can use an identity proxy if we want to use a CSRF token (see token storage below)
-      // customAPI: "", // might be used with the identityProxy, to proxy through a custom backend service.
+      // customContentApiUrl: "", // might be used to swap out or proxy through a custom backend service.
       // tokenStorage: (Default Memory). Possible values: "MEMORY" | "LOCAL_STORAGE" | "CUSTOM".
       // NOTE: If you choose to use LOCAL_STORAGE, you may be prone to CSRF vulnerabilities.
       // getTokenFn: undefined, // This is only used when "tokenStorage" is set to "CUSTOM". Instead of grabbing the token from local storage, we can specify how its access token is retreived. You might want to use this if you are fetching content server-side.

--- a/packages/client/src/client/index.ts
+++ b/packages/client/src/client/index.ts
@@ -38,24 +38,21 @@ interface AddVariables {
   params?: any;
 }
 
-const TINA_BACKEND_URL =
-  "https://82ptjhdl6d.execute-api.ca-central-1.amazonaws.com/dev";
-
 interface ServerOptions {
   realm: string;
   clientId: string;
   branch: string;
   redirectURI: string;
-  customAPI?: string;
-  identityProxy?: string;
+  customContentApiUrl?: string;
+  customTinaCloudApiUrl?: string;
   getTokenFn?: () => TokenObject;
   tokenStorage?: "MEMORY" | "LOCAL_STORAGE" | "CUSTOM";
 }
 
 export class Client {
-  serverURL: string;
+  contentApiUrl: string;
   realm: string;
-  tinaBackendUrl: string;
+  tinaCloudApiUrl: string;
   schema: GraphQLSchema;
   clientId: string;
   query: string;
@@ -66,10 +63,10 @@ export class Client {
 
   constructor({ tokenStorage = "MEMORY", ...options }: ServerOptions) {
     const _this = this;
-    (this.serverURL =
-      options.customAPI ||
+    (this.contentApiUrl =
+      options.customContentApiUrl ||
       `https://content.tinajs.dev/github/${options.realm}/${options.clientId}/${options.branch}`),
-      (this.tinaBackendUrl = TINA_BACKEND_URL);
+    this.tinaCloudApiUrl = options.customTinaCloudApiUrl || "auth.ca-central-1.amazoncognito.com";
     this.redirectURI = options.redirectURI;
     this.clientId = options.clientId;
     this.realm = options.realm;
@@ -236,7 +233,7 @@ export class Client {
     query: ((gqlTag: typeof gql) => DocumentNode) | string,
     { variables }: { variables: VariableType }
   ) {
-    const res = await fetch(this.serverURL, {
+    const res = await fetch(this.contentApiUrl, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -282,7 +279,7 @@ export class Client {
   }
 
   async getUser() {
-    const url = `${this.tinaBackendUrl}/currentUser`;
+    const url = `${this.tinaCloudApiUrl}/currentUser`;
 
     try {
       const res = await fetch(url, {


### PR DESCRIPTION
Make the names of the 2 API options a bit more explicit. Also make the `customTinaCloudApiUrl` within the client creation