### PR TITLE
Update graphql api route

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tina-graphql-gateway",
-  "version": "0.1.50",
+  "version": "0.1.51",
   "main": "dist/index.js",
   "files": [
     "dist/*"

--- a/packages/client/src/client/index.ts
+++ b/packages/client/src/client/index.ts
@@ -64,7 +64,7 @@ export class Client {
     const _this = this;
     (this.contentApiUrl =
       options.customContentApiUrl ||
-      `https://content.tinajs.dev/github/${options.realm}/${options.clientId}/${options.branch}`),
+      `https://content.tinajs.dev/content/${options.realm}/${options.clientId}/github/${options.branch}`),
       (this.clientId = options.clientId);
     this.realm = options.realm;
 


### PR DESCRIPTION
updating Github's new API route from moving to serverless