### PR TITLE
Useform refactor

### DIFF
--- a/packages/client/src/hooks/use-form.ts
+++ b/packages/client/src/hooks/use-form.ts
@@ -189,7 +189,7 @@ const formsMachine = createMachine<FormsContext, FormsEvent, FormsState>({
   },
 });
 
-const useAddSectionPagePlugin = (onNewDocument?: OnNewDocument) => 
+const useAddSectionDocumentPlugin = (onNewDocument?: OnNewDocument) => 
 {
   const cms = useCMS();
 
@@ -247,7 +247,7 @@ const useAddSectionPagePlugin = (onNewDocument?: OnNewDocument) =>
   }, [cms]);
 }
 
-function useFormattedPayload<T extends object>(  {
+function useRegisterFormsAndSyncPayload<T extends object>(  {
   payload,
   onSubmit,
 }: {
@@ -332,9 +332,9 @@ export function useForm<T extends object>({
   // TODO - Should we pull this out of this file. 
   // Or return it as a factory function which can 
   // optionally be called.
-  useAddSectionPagePlugin(onNewDocument)
+  useAddSectionDocumentPlugin(onNewDocument)
 
-  const {data, retry} = useFormattedPayload({payload,onSubmit})
+  const { data, retry } = useRegisterFormsAndSyncPayload({payload,onSubmit})
 
   React.useEffect(() => {
     retry()


### PR DESCRIPTION
Wanted to make it more obvious what useForm is doing under the hood. I wanted to encapsulate the xState stuff as much as possible. I broke things out into a few sub-hooks:
`useAddSectionDocumentPlugin` & `useRegisterFormsAndSyncPayload`.

I think a future step will be to refactor `useRegisterFormsAndSyncPayload` (and `createFormMachine`) to simplify this function's role, & pull out the form registration. 

Still need to test this, so opening as a draft for now. 