### PR TITLE
avoid automatically registering the document creator plugin when calling useForm

### DIFF
--- a/packages/client/readme.md
+++ b/packages/client/readme.md
@@ -455,9 +455,17 @@ We hope to offer the best of both options, using Tina forms while still having a
 So to continue on with the code samples from above, passing the payload into the `useForm` hook will initialize a form for each node in the query:
 
 ```ts
+import { useForm, useDocumentCreatorPlugin } from "tina-graphql-gateway";
+
+//...
+
 const result = useForm({
   // pass the payload from your request
   payload: payload,
+});
+
+// adds a document creator plugin for adding new documents based on your section configuration
+useDocumentCreatorPlugin({
   // When creating a new document, you'll likely want to redirect the user to it.
   // `args` provides information about the file you've created and the section it belongs to.
   onNewDocument: (args) => {

--- a/packages/client/src/hooks/use-form.ts
+++ b/packages/client/src/hooks/use-form.ts
@@ -199,7 +199,7 @@ const formsMachine = createMachine<FormsContext, FormsEvent, FormsState>({
   },
 });
 
-const useAddSectionDocumentPlugin = (onNewDocument?: OnNewDocument) => {
+export const useDocumentCreatorPlugin = (onNewDocument?: OnNewDocument) => {
   const cms = useCMS();
 
   React.useEffect(() => {
@@ -333,21 +333,14 @@ function useRegisterFormsAndSyncPayload<T extends object>({
 export function useForm<T extends object>({
   payload,
   onSubmit,
-  onNewDocument,
   formify = null,
 }: {
   payload: T;
   onSubmit?: (args: { queryString: string; variables: object }) => void;
-  onNewDocument?: OnNewDocument;
   formify?: formifyCallback;
 }): [T, Form[]] {
   // @ts-ignore FIXME: need to ensure the payload has been hydrated with Tina-specific stuff
   const queryString = payload._queryString;
-
-  // TODO - Should we pull this out of this file.
-  // Or return it as a factory function which can
-  // optionally be called.
-  useAddSectionDocumentPlugin(onNewDocument);
 
   const { data, retry } = useRegisterFormsAndSyncPayload({
     payload,


### PR DESCRIPTION
`useForm` no longer automatically sets up the document creator plugin; the `useDocumentCreatorPlugin` is now exported separately and should be called by the consumer

closes #146 