### PR TITLE
Bump cli version to 0.2.38

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tina-graphql-gateway-cli",
-  "version": "0.2.37",
+  "version": "0.2.38",
   "main": "dist/index.js",
   "files": [
     "dist/*",


### PR DESCRIPTION
Bit of a crash course in how these packages are organized.
From 0.2.37 to 0.2.38