### PR TITLE
feat: Add filtering to collections in Add Document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,11 @@ Currently this is a monorepo built with Yarn V2 and Plug-n-Play. This is a more 
 You should :fingers_crossed: be able to just run these commands. (Please make a note of any hang-ups you ran into during this process)
 
 ```sh
-# check yarn version, this repo ships with yarn so it should be 2.1.1
+# check the node version, this repo only supports node 14.x.x at the moment
+node -v
+# check yarn version, this repo ships with yarn so it should be 2.4.1
 yarn -v
-# if that doesn't show 2.1.1 it needs to be fixed. You can install the version manually https://yarnpkg.com/getting-started/install but you'll definitely need +2.0
+# it should show 2.4.1, you'll definitely need +2.0
 yarn install
 # build all the packages
 yarn run build

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tina-graphql-gateway",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "main": "dist/index.js",
   "files": [
     "dist/*"

--- a/packages/client/src/hooks/use-graphql-forms.ts
+++ b/packages/client/src/hooks/use-graphql-forms.ts
@@ -148,7 +148,17 @@ const formsMachine = createMachine<FormsContext, FormsEvent, FormsState>({
   },
 });
 
-export const useDocumentCreatorPlugin = (onNewDocument?: OnNewDocument) => {
+export type FilterCollections = (
+  options: {
+    label: string;
+    value: string;
+  }[]
+) => { label: string; value: string }[];
+
+export const useDocumentCreatorPlugin = (
+  onNewDocument?: OnNewDocument,
+  filterCollections?: FilterCollections
+) => {
   const cms = useCMS();
 
   React.useEffect(() => {
@@ -165,13 +175,20 @@ export const useDocumentCreatorPlugin = (onNewDocument?: OnNewDocument) => {
           `,
           { variables: {} }
         );
-        const options = [{ value: "", label: "Choose Collection" }];
+        const emptyOption = { value: "", label: "Choose Collection" };
+        const options: { label: string; value: string }[] = [];
         res.getCollections.forEach((collection) => {
           const value = collection.slug;
           const label = `${collection.label}`;
           options.push({ value, label });
         });
-        return options;
+
+        if (filterCollections && typeof filterCollections === "function") {
+          const filtered = filterCollections(options);
+          return [emptyOption, ...filtered];
+        }
+
+        return [emptyOption, ...options];
       };
 
       const getCollectionTemplateOptions = async (collection: String) => {


### PR DESCRIPTION
Jeff had the idea that it would be better Dx if we allowed for filtering of `collections` in the "Add Document" content creator.

This just adds an optional param (`filterCollections`) to `useDocumentCreatorPlugin` that provides the list of `options` and returns a (potentially) filtered list of `options`.

Closes https://github.com/tinacms/tina-graphql-gateway/issues/175

I also updated the CONTRIBUTING readme after we learned that yarn v2+ is not supported with Node >14.