### PR TITLE
186 - Warns when collection.path does not exist

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tina-graphql-gateway-cli",
-  "version": "0.2.40",
+  "version": "0.2.41",
   "main": "dist/index.js",
   "files": [
     "dist/*",


### PR DESCRIPTION
Checks `collection.path` against the filesystem prior to compiling the schema and provides a warning if the `path` does not exist.

Downstream, missing a `path` can cause issues with both `reference` and `reference-list` fields.

Closes #186 

<img width="736" alt="Screen Shot 2021-05-11 at 9 19 07 AM" src="https://user-images.githubusercontent.com/1699544/117831255-0237f100-b23a-11eb-9b9b-937e01eaf1f7.png">


