### PR TITLE
217 - Adds `description` to FormFieldBuilder

### DIFF
--- a/packages/tina-graphql/package.json
+++ b/packages/tina-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tina-graphql",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "files": [

--- a/packages/tina-graphql/src/fields/blocks/block.spec.ts
+++ b/packages/tina-graphql/src/fields/blocks/block.spec.ts
@@ -32,23 +32,27 @@ describe(`Type ${field.type} builds`, () => {
         name: String
         label: String
         component: String
+        description: String
       }
       type TextField implements FormField {
         name: String
         label: String
         component: String
+        description: String
       }
       union Post_Details_FormFieldsUnion = TextField
       type Post_Details_GroupField implements FormField {
         name: String
         label: String
         component: String
+        description: String
         fields: [Post_Details_FormFieldsUnion]
       }
       type SelectField implements FormField {
         name: String
         label: String
         component: String
+        description: String
         options: [String]
       }
       union Post_FormFieldsUnion =
@@ -67,6 +71,7 @@ describe(`Type ${field.type} builds`, () => {
         name: String
         label: String
         component: String
+        description: String
         templates: MyBlocks_BlocksFieldTemplates
       }
       union Sample_FormFieldsUnion = MyBlocks_BlocksField

--- a/packages/tina-graphql/src/fields/field-group-list/field-group-list.spec.ts
+++ b/packages/tina-graphql/src/fields/field-group-list/field-group-list.spec.ts
@@ -39,12 +39,14 @@ describe(`Field of type ${field.type} builds`, () => {
         name: String
         label: String
         component: String
+        description: String
       }
       union SomeGroup_FormFieldsUnion = TextField
       type SomeGroup_GroupListField implements FormField {
         name: String
         label: String
         component: String
+        description: String
         fields: [SomeGroup_FormFieldsUnion]
       }
       union Sample_FormFieldsUnion = SomeGroup_GroupListField

--- a/packages/tina-graphql/src/fields/field-group/field-group.spec.ts
+++ b/packages/tina-graphql/src/fields/field-group/field-group.spec.ts
@@ -39,12 +39,14 @@ describe(`Field of type ${field.type} builds`, () => {
         name: String
         label: String
         component: String
+        description: String
       }
       union SomeGroup_FormFieldsUnion = TextField
       type SomeGroup_GroupField implements FormField {
         name: String
         label: String
         component: String
+        description: String
         fields: [SomeGroup_FormFieldsUnion]
       }
       union Sample_FormFieldsUnion = SomeGroup_GroupField

--- a/packages/tina-graphql/src/fields/list/list.spec.ts
+++ b/packages/tina-graphql/src/fields/list/list.spec.ts
@@ -33,11 +33,13 @@ describe(`Field of type ${field.type} builds`, () => {
         name: String
         label: String
         component: String
+        description: String
       }
       type SelectField implements FormField {
         name: String
         label: String
         component: String
+        description: String
         options: [String]
       }
       union List_FormFieldsUnion = TextField | SelectField
@@ -45,6 +47,7 @@ describe(`Field of type ${field.type} builds`, () => {
         name: String
         label: String
         component: String
+        description: String
         defaultItem: String
         field: List_FormFieldsUnion
       }

--- a/packages/tina-graphql/src/fields/select/select.spec.ts
+++ b/packages/tina-graphql/src/fields/select/select.spec.ts
@@ -36,6 +36,7 @@ describe(`Field of type ${field.type} builds`, () => {
         name: String
         label: String
         component: String
+        description: String
         options: [String]
       }
       union Sample_FormFieldsUnion = SelectField

--- a/packages/tina-graphql/src/fields/text/text.spec.ts
+++ b/packages/tina-graphql/src/fields/text/text.spec.ts
@@ -31,6 +31,7 @@ describe(`Field of type ${field.type} builds`, () => {
         name: String
         label: String
         component: String
+        description: String
       }
       union Sample_FormFieldsUnion = TextField
       type Sample_Form {

--- a/packages/tina-graphql/src/fields/textarea/textarea.spec.ts
+++ b/packages/tina-graphql/src/fields/textarea/textarea.spec.ts
@@ -31,6 +31,7 @@ describe(`Field of type ${field.type} builds`, () => {
         name: String
         label: String
         component: String
+        description: String
       }
       union Sample_FormFieldsUnion = TextareaField
       type Sample_Form {

--- a/packages/tina-graphql/src/gql/index.ts
+++ b/packages/tina-graphql/src/gql/index.ts
@@ -34,7 +34,7 @@ import {
 export const gql = {
   /**
    * `FormFieldBuilder` acts as a shortcut to building an entire `ObjectTypeDefinition`, we use this
-   * because all Tina field objects share a common set of fields ('name', 'label', 'component')
+   * because all Tina field objects share a common set of fields ('name', 'label', 'component', 'description')
    */
   FormFieldBuilder: ({
     name,
@@ -50,6 +50,7 @@ export const gql = {
         gql.FieldDefinition({ name: "name", type: gql.TYPES.String }),
         gql.FieldDefinition({ name: "label", type: gql.TYPES.String }),
         gql.FieldDefinition({ name: "component", type: gql.TYPES.String }),
+        gql.FieldDefinition({ name: "description", type: gql.TYPES.String }),
         ...(additionalFields || []),
       ],
     });


### PR DESCRIPTION
Like `name`, `label`, and `component`, `description` is another common field to all Tina Fields.

This adds `description` to the `gql.ObjectTypeDefinition()`, allowing it to be queried when building all Tina `fields`.

Closes #217 