### PR TITLE
fix: adds encodeURIComponent() to branch 

### DIFF
--- a/packages/tina-graphql-gateway/package.json
+++ b/packages/tina-graphql-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tina-graphql-gateway",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "main": "dist/index.js",
   "files": [
     "dist/*"

--- a/packages/tina-graphql-gateway/src/client/index.ts
+++ b/packages/tina-graphql-gateway/src/client/index.ts
@@ -55,10 +55,15 @@ export class Client {
 
   constructor({ tokenStorage = "MEMORY", ...options }: ServerOptions) {
     const _this = this;
+    /**
+     * Prevents a CORS-issue when the `branch` has slashes in it.
+     * https://github.com/tinacms/tina-graphql-gateway/issues/219
+     */
+    const encodedBranch = encodeURIComponent(options.branch);
     (this.contentApiUrl =
       options.customContentApiUrl ||
-      `${CONTENT_API_URL}/content/${options.organizationId}/${options.clientId}/github/${options.branch}`),
-      // `https://content.tinajs.dev/content/${options.organizationId}/${options.clientId}/github/${options.branch}`),
+      `${CONTENT_API_URL}/content/${options.organizationId}/${options.clientId}/github/${encodedBranch}`),
+      // `https://content.tinajs.dev/content/${options.organizationId}/${options.clientId}/github/${encodedBranch}`),
       (this.clientId = options.clientId);
     this.organizationId = options.organizationId;
 


### PR DESCRIPTION
Pretty straightforward, though it does rely on:
https://github.com/tinacms/teams-serverless/issues/427

to fully work.

Simply takes `options.branch` and runs `encodeURIComponent()` against it:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent

Closes #219 