### PR TITLE
Chore/version bump test

### DIFF
--- a/packages/tina-graphql-gateway-cli/package.json
+++ b/packages/tina-graphql-gateway-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tina-graphql-gateway-cli",
-  "version": "0.2.50",
+  "version": "0.2.51-0",
   "main": "dist/index.js",
   "files": [
     "dist/*",


### PR DESCRIPTION
I was trying to see if publishing with `yarn npm publish` worked and fixed our error. Sadly it did not. We should merge this so that the version is up to date in main.