### PR TITLE
Export S3 Cache

### DIFF
--- a/packages/tina-graphql/package.json
+++ b/packages/tina-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tina-graphql",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "files": [

--- a/packages/tina-graphql/src/index.ts
+++ b/packages/tina-graphql/src/index.ts
@@ -18,11 +18,10 @@ import { buildASTSchema } from 'graphql'
 import { createDatasource } from './datasources/data-manager'
 import { GithubManager } from './datasources/github-manager'
 import { FileSystemManager } from './datasources/filesystem-manager'
-import { clearCache as s3ClearCache } from './cache/s3'
+import { clearCache as s3ClearCache, s3Cache } from './cache/s3'
 import { simpleCache, clearCache as lruClearCache } from './cache/lru'
-import { Cache } from './cache'
 
-export { lruClearCache, s3ClearCache }
+export { lruClearCache, s3ClearCache, s3Cache }
 
 export const gql = async ({
   projectRoot,


### PR DESCRIPTION
Export S3 cache from tina-graphql package.

I forgot to export the cache before, need it to be able to override the simple cache when using the githubRoute function.