### PR TITLE
bump version of tina-graphql-gateway

### DIFF
--- a/packages/tina-graphql-gateway/package.json
+++ b/packages/tina-graphql-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tina-graphql-gateway",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "main": "dist/index.js",
   "files": [
     "dist/*"


### PR DESCRIPTION
When merging https://github.com/tinacms/tina-graphql-gateway/pull/254 In CI I got this error message
```
➤ YN0000: [next-tinacms-cloudinary]: ➤ YN0000: Registry already knows about version 0.1.2; skipping.
➤ YN0000: [next-tinacms-cloudinary]: ➤ YN0000: Done with warnings in 0s 439ms

➤ YN0000: [tina-cloud-next]: ➤ YN0000: Registry already knows about version 0.0.3; skipping.
➤ YN0000: [tina-cloud-next]: ➤ YN0000: Done with warnings in 0s 335ms

➤ YN0000: [tina-graphql]: ➤ YN0000: Registry already knows about version 0.1.16; skipping.
➤ YN0000: [tina-graphql]: ➤ YN0000: Done with warnings in 0s 435ms

➤ YN0000: MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 uncaughtException listeners added to [process]. Use emitter.setMaxListeners() to increase limit
➤ YN0000: [tina-graphql-gateway]: ➤ YN0000: Registry already knows about version 0.2.19; skipping.
➤ YN0000: [tina-graphql-gateway]: ➤ YN0000: Done with warnings in 0s 520ms

➤ YN0000: [tina-graphql-gateway-cli]: ➤ YN0000: Registry already knows about version 0.2.51; skipping.
➤ YN0000: [tina-graphql-gateway-cli]: ➤ YN0000: Done with warnings in 0s 589ms

➤ YN0000: [tina-graphql-helpers]: ➤ YN0000: Registry already knows about version 0.0.23; skipping.
➤ YN0000: [tina-graphql-helpers]: ➤ YN0000: Done with warnings in 0s 327ms
➤ YN0000: Done with warnings in 4s 860ms
```
It seems that 2.19 was already published so this PR bumps the version to 2.19 so that PR will actually publish.