### PR TITLE
Removed AWS info from s3 client

### DIFF
--- a/packages/tina-graphql/package.json
+++ b/packages/tina-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tina-graphql",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "files": [

--- a/packages/tina-graphql/src/cache/s3.ts
+++ b/packages/tina-graphql/src/cache/s3.ts
@@ -16,10 +16,7 @@ import { S3 } from 'aws-sdk'
 
 const bucketName = process.env.CACHE_S3_BUCKET_NAME || 'tina-contentapi'
 
-const realCache = new S3({
-  accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-  secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-})
+const realCache = new S3()
 
 export const clearCacheWith =
   (cache: S3) =>


### PR DESCRIPTION
Remove the ID and secret key from creating the S3 client.

Lambda functions already handle this for us, and by setting it we're getting in the way. 