### PR TITLE
bump version of tina-graphql-gateway

### DIFF
--- a/packages/tina-graphql-gateway/package.json
+++ b/packages/tina-graphql-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tina-graphql-gateway",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "main": "dist/index.js",
   "files": [
     "dist/*"


### PR DESCRIPTION
I bumped the version of the wrong package in https://github.com/tinacms/tina-graphql-gateway/pull/301. So tina-graphql-gateway did not get published.  