### PR TITLE
docs: make sure you don't forget the build step

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,9 @@ Previous PRs to main would _not_ have triggered NPM packages to be published bec
 
 ## Creating a dev release
 
-Ensure you have created a changeset and have a clean `git` working directory
+Ensure you have created a changeset and have a clean `git` working directory. 
+
+Build your changes with `yarn build`
 
 Run `yarn changeset version --snapshot`
 


### PR DESCRIPTION
I'm such a JS amateur that this didn't come naturally to me and I spent a lot of time pushing identical builds to npm.